### PR TITLE
Add `path` attribute to `Process` struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ pub struct Process {
     pub pid: u32,
     /// Process name.
     pub name: String,
+    /// Process path.
+    pub path: String,
 }
 
 /// The protocol used by the listener.
@@ -162,8 +164,8 @@ pub fn get_ports_by_process_name(name: &str) -> Result<HashSet<u16>> {
 }
 
 impl Listener {
-    fn new(pid: u32, name: String, socket: SocketAddr, protocol: Protocol) -> Self {
-        let process = Process::new(pid, name);
+    fn new(pid: u32, name: String, path: String, socket: SocketAddr, protocol: Protocol) -> Self {
+        let process = Process::new(pid, name, path);
         Self {
             process,
             socket,
@@ -173,8 +175,8 @@ impl Listener {
 }
 
 impl Process {
-    fn new(pid: u32, name: String) -> Self {
-        Self { pid, name }
+    fn new(pid: u32, name: String, path: String) -> Self {
+        Self { pid, name, path }
     }
 }
 
@@ -192,7 +194,7 @@ impl Display for Listener {
 
 impl Display for Process {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Process { pid, name } = self;
+        let Process { pid, name, .. } = self;
         write!(f, "PID: {pid:<10} Process name: {name}")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,6 +219,7 @@ mod tests {
         let listener = Listener::new(
             455,
             "rapportd".to_string(),
+            "path/to/rapportd".to_string(),
             SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 51189),
             Protocol::TCP,
         );
@@ -233,6 +234,7 @@ mod tests {
         let listener = Listener::new(
             160,
             "mysqld".to_string(),
+            "path/to/mysqld".to_string(),
             SocketAddr::new(IpAddr::V6(Ipv6Addr::UNSPECIFIED), 3306),
             Protocol::UDP,
         );
@@ -244,7 +246,11 @@ mod tests {
 
     #[test]
     fn test_process_to_string() {
-        let process = Process::new(611, "Microsoft SharePoint".to_string());
+        let process = Process::new(
+            611,
+            "Microsoft SharePoint".to_string(),
+            "path/to/sharepoint".to_string(),
+        );
         assert_eq!(
             process.to_string(),
             "PID: 611        Process name: Microsoft SharePoint"

--- a/src/platform/linux/mod.rs
+++ b/src/platform/linux/mod.rs
@@ -22,6 +22,7 @@ pub(crate) fn get_all() -> crate::Result<HashSet<Listener>> {
             let listener = Listener::new(
                 p.pid(),
                 p.name(),
+                p.path(),
                 proto_listener.local_addr(),
                 proto_listener.protocol(),
             );

--- a/src/platform/macos/c_libproc.rs
+++ b/src/platform/macos/c_libproc.rs
@@ -32,3 +32,11 @@ extern "C" {
 extern "C" {
     pub(super) fn proc_name(pid: c_int, buffer: *mut c_void, buffersize: u32) -> c_int;
 }
+
+extern "C" {
+    pub fn proc_pidpath(
+        pid: ::std::os::raw::c_int,
+        buffer: *mut ::std::os::raw::c_void,
+        buffersize: u32,
+    ) -> ::std::os::raw::c_int;
+}

--- a/src/platform/macos/mod.rs
+++ b/src/platform/macos/mod.rs
@@ -5,12 +5,14 @@ use proc_pid::ProcPid;
 use proto_listener::ProtoListener;
 use socket_fd::SocketFd;
 
+use crate::platform::macos::proc_path::ProcPath;
 use crate::Listener;
 
 mod c_libproc;
 mod c_proc_fd_info;
 mod c_socket_fd_info;
 mod proc_name;
+mod proc_path;
 mod proc_pid;
 mod proto_listener;
 mod socket_fd;
@@ -23,13 +25,16 @@ pub(crate) fn get_all() -> crate::Result<HashSet<Listener>> {
         for fd in SocketFd::get_all_of_pid(pid).iter().flatten() {
             if let Ok(proto_listener) = ProtoListener::from_pid_fd(pid, fd) {
                 if let Ok(ProcName(name)) = ProcName::from_pid(pid) {
-                    let listener = Listener::new(
-                        pid.as_u_32()?,
-                        name,
-                        proto_listener.socket_addr(),
-                        proto_listener.protocol(),
-                    );
-                    listeners.insert(listener);
+                    if let Ok(ProcPath(path)) = ProcPath::from_pid(pid) {
+                        let listener = Listener::new(
+                            pid.as_u_32()?,
+                            name,
+                            path,
+                            proto_listener.socket_addr(),
+                            proto_listener.protocol(),
+                        );
+                        listeners.insert(listener);
+                    }
                 }
             }
         }

--- a/src/platform/macos/proc_path.rs
+++ b/src/platform/macos/proc_path.rs
@@ -1,0 +1,38 @@
+use std::ffi::c_void;
+
+use crate::platform::macos::c_libproc::proc_pidpath;
+use crate::platform::macos::proc_pid::ProcPid;
+use crate::platform::macos::statics::PROC_PID_PATH_INFO_MAXSIZE;
+
+#[derive(Default)]
+pub(super) struct ProcPath(pub(super) String);
+
+impl ProcPath {
+    fn new(path: String) -> Self {
+        ProcPath(path)
+    }
+
+    pub(super) fn from_pid(pid: ProcPid) -> crate::Result<Self> {
+        let mut buf: Vec<u8> = Vec::with_capacity(PROC_PID_PATH_INFO_MAXSIZE);
+        let buffer_ptr = buf.as_mut_ptr().cast::<c_void>();
+        let buffer_size = u32::try_from(buf.capacity())?;
+
+        let ret;
+        unsafe {
+            ret = proc_pidpath(pid.as_c_int(), buffer_ptr, buffer_size);
+        };
+
+        if ret <= 0 {
+            return Err("Failed to get process path".into());
+        }
+
+        unsafe {
+            buf.set_len(usize::try_from(ret)?);
+        }
+
+        match String::from_utf8(buf) {
+            Ok(path) => Ok(Self::new(path)),
+            Err(_) => Err("Invalid UTF sequence for process path".into()),
+        }
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -56,6 +56,7 @@ fn test_http_server() {
 
     let http_server_name = http_server_process.name.clone();
     let http_server_pid = http_server_process.pid;
+    let http_server_path = http_server_process.path;
 
     // get the http server port by its process name
     // and check that it is the same as the one of the http server
@@ -82,7 +83,8 @@ fn test_http_server() {
         &Listener {
             process: Process {
                 pid: http_server_pid,
-                name: http_server_name
+                name: http_server_name,
+                path: http_server_path
             },
             socket: SocketAddr::from_str(&format!("127.0.0.1:{http_server_port}")).unwrap(),
             protocol: Protocol::TCP


### PR DESCRIPTION
Add `path` attribute to `Process` struct, making it possible to obtain the path of the executables